### PR TITLE
Jim/062722/precommit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,378 @@
+{
+  "version": "1.2.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "3bf710d852e4ffb2bf157dccd3e6099d9cd6654f",
+        "is_verified": false,
+        "line_number": 30
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "fc5462be70401cb2f7940d506ff413e722bb9bbd",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
+    "app/config.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/config.py",
+        "hashed_secret": "577a4c667e4af8682ca431857214b3a920883efc",
+        "is_verified": false,
+        "line_number": 432
+      }
+    ],
+    "app/models.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "app/models.py",
+        "hashed_secret": "12322e07b94ee3c7cd65a2952ece441538b53eb3",
+        "is_verified": false,
+        "line_number": 1891
+      }
+    ],
+    "docker-compose.devcontainer.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.devcontainer.yml",
+        "hashed_secret": "5b98cf4c3d794c8af1fcd7991e89cd4e52fb42a4",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "migrations/versions/0025_notify_service_data.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "migrations/versions/0025_notify_service_data.py",
+        "hashed_secret": "14153c7b93d1070d1579eb85d81cf660b330befc",
+        "is_verified": false,
+        "line_number": 83
+      }
+    ],
+    "pytest.ini": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pytest.ini",
+        "hashed_secret": "e501a39b67f82817f7ec580a36f6932e5377e59c",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "pytest.ini",
+        "hashed_secret": "a3e8fada29009777b0855fa5fadeb0bb91de4ef6",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "sample.env": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "sample.env",
+        "hashed_secret": "5b98cf4c3d794c8af1fcd7991e89cd4e52fb42a4",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "tests/app/authentication/test_authentication.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/authentication/test_authentication.py",
+        "hashed_secret": "9ba831ebe84a351453e3bd542a5e692316120170",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/authentication/test_authentication.py",
+        "hashed_secret": "23332b8380ee6a1c573083631c41d8d5130e8d2a",
+        "is_verified": false,
+        "line_number": 186
+      }
+    ],
+    "tests/app/aws/test_s3.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/aws/test_s3.py",
+        "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "tests/app/clients/test_cbc_proxy.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_cbc_proxy.py",
+        "hashed_secret": "ba59e920f3d2ebb6a219a8b7e40ecb606ea697dd",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "tests/app/clients/test_document_download.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/clients/test_document_download.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "tests/app/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/conftest.py",
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_verified": false,
+        "line_number": 620
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/conftest.py",
+        "hashed_secret": "4ff75f80957469c4b6af5824cb99bf4919abad98",
+        "is_verified": false,
+        "line_number": 621
+      }
+    ],
+    "tests/app/dao/test_services_dao.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_services_dao.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 259
+      }
+    ],
+    "tests/app/dao/test_users_dao.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_users_dao.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/dao/test_users_dao.py",
+        "hashed_secret": "f2c57870308dc87f432e5912d4de6f8e322721ba",
+        "is_verified": false,
+        "line_number": 164
+      }
+    ],
+    "tests/app/db.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "2020f1df1bb8bbe6d7f3e6b2d136cd2a38ad7fed",
+        "is_verified": false,
+        "line_number": 891
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/app/db.py",
+        "hashed_secret": "0362114f115be22057673eda269208449bec65ff",
+        "is_verified": false,
+        "line_number": 892
+      }
+    ],
+    "tests/app/letters/test_returned_letters.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/letters/test_returned_letters.py",
+        "hashed_secret": "d782ccb6785b5e3cef91a149f946a38cea88fb81",
+        "is_verified": false,
+        "line_number": 5
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/letters/test_returned_letters.py",
+        "hashed_secret": "52f1e518a8f64e70f1f443eebe7cdd2e8cdaf83f",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "tests/app/notifications/test_receive_notification.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/notifications/test_receive_notification.py",
+        "hashed_secret": "913a73b565c8e2c8ed94497580f619397709b8b6",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "tests/app/notifications/test_validators.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/notifications/test_validators.py",
+        "hashed_secret": "9c2a6e4809aeef7b7712ca4db05a681452f4f748",
+        "is_verified": false,
+        "line_number": 401
+      }
+    ],
+    "tests/app/service/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/service/test_rest.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 1297
+      }
+    ],
+    "tests/app/template/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/template/test_rest.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 1168
+      }
+    ],
+    "tests/app/user/test_rest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/user/test_rest.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/app/user/test_rest.py",
+        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
+        "is_verified": false,
+        "line_number": 889
+      }
+    ],
+    "tests/app/v2/broadcast/test_post_broadcast.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/v2/broadcast/test_post_broadcast.py",
+        "hashed_secret": "afddbc89a4e7b99f99eb0b1fad44d7aed566c77f",
+        "is_verified": false,
+        "line_number": 99
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/app/v2/broadcast/test_post_broadcast.py",
+        "hashed_secret": "a1f83866aff48443fffba0f8c6f11da4ad2e6763",
+        "is_verified": false,
+        "line_number": 215
+      }
+    ]
+  },
+  "generated_at": "2022-06-27T21:40:11Z"
+}

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,5 +1,4 @@
 SECRET_KEY: "dev-notify-secret-key" # pragma: allowlist secret
-SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/" # pragma: allowlist secret
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>
 AWS_SECRET_ACCESS_KEY: <replace me>

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,6 +1,6 @@
 SECRET_KEY: "dev-notify-secret-key" # pragma: allowlist secret
 SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/"
-TEMP: temps
+TEMP: tempsss
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>
 AWS_SECRET_ACCESS_KEY: <replace me>

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,6 +1,5 @@
 SECRET_KEY: "dev-notify-secret-key" # pragma: allowlist secret
-SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/"
-TEMP: tempssss
+SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/" # pragma: allowlist secret
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>
 AWS_SECRET_ACCESS_KEY: <replace me>

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,6 +1,6 @@
 SECRET_KEY: "dev-notify-secret-key" # pragma: allowlist secret
 SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/"
-TEMP: tempsss
+TEMP: tempssss
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>
 AWS_SECRET_ACCESS_KEY: <replace me>

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,4 +1,3 @@
-
 SECRET_KEY: "dev-notify-secret-key"
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>

--- a/varsfile.sample
+++ b/varsfile.sample
@@ -1,4 +1,6 @@
-SECRET_KEY: "dev-notify-secret-key"
+SECRET_KEY: "dev-notify-secret-key" # pragma: allowlist secret
+SECRET_TEST: "nfn3ofubgrp93aowt44o8tgvbaie7a+asdfacblaibg+afce?asdgarw/"
+TEMP: temps
 DANGEROUS_SALT: "dev-notify-salt"
 AWS_ACCESS_KEY_ID: <replace me>
 AWS_SECRET_ACCESS_KEY: <replace me>


### PR DESCRIPTION
**Quick Start**
```
brew install detect-secrets # or pip install detect-secrets
detect-secrets scan
#review output of above, make sure none of the baseline entries are sensitive
detect-secrets scan > .secrets.baseline
#creates the baseline file
```

Ideally, you'll install `detect-secrets` so that it's accessible from any environment from which you _might_ commit. You can use `brew install` to make it available globally. You could also install via `pip install` inside a virtual environment, if you're sure you'll _only_ commit from that environment.

If you open .git/hooks/pre-commit you should see a simple bash script that runs the command below, reads the output and aborts before committing if detect-secrets finds a secret. You should be able to test it by staging a file with any high-entropy string like `"bblfwk3u4bt484+afw4avev5ae+afr4?/fa"` (it also has other ways to detect secrets, this is just the most straightforward to test). 

You can permit exceptions by adding an inline comment containing `pragma: allowlist secret`

The command that is actually run by the pre-commit hook is: `git diff --staged --name-only -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline`

You can also run against all tracked files staged or not: `git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline`