### PR TITLE
notify-api-317 try adding cloudwatch to allow acl for egress proxy

### DIFF
--- a/deploy-config/egress_proxy/notify-api-demo.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-demo.allow.acl
@@ -1,3 +1,4 @@
+cloudwatch.us-west-2.amazonaws.com
 email.us-west-2.amazonaws.com
 sns.us-east-1.amazonaws.com
 gov-collector.newrelic.com

--- a/deploy-config/egress_proxy/notify-api-production.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-production.allow.acl
@@ -1,3 +1,4 @@
+cloudwatch.us-west-2.amazonaws.com
 email.us-gov-west-1.amazonaws.com
 sns.us-gov-west-1.amazonaws.com
 gov-collector.newrelic.com

--- a/deploy-config/egress_proxy/notify-api-staging.allow.acl
+++ b/deploy-config/egress_proxy/notify-api-staging.allow.acl
@@ -1,3 +1,4 @@
+cloudwatch.us-west-2.amazonaws.com
 email.us-west-2.amazonaws.com
 sns.us-west-2.amazonaws.com
 gov-collector.newrelic.com


### PR DESCRIPTION
Since the problem we are facing is that our aws_cloudwatch_client cannot connect to the egress proxy when trying to access CloudWatch Logs from staging, I'm wondering if adding cloudwatch to the egress proxy allow acts would help.