### PR TITLE
kill workers after 20 tasks

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -166,6 +166,7 @@ class Config(object):
     current_minute = (datetime.now().minute + 1) % 60
 
     CELERY = {
+        "worker_max_tasks_per_child": 20,
         "broker_url": REDIS_URL,
         "broker_transport_options": {
             "visibility_timeout": 310,


### PR DESCRIPTION
## Description

Kill celery workers after 20 tasks to prevent resource leakage.

https://docs.celeryq.dev/en/v5.4.0/userguide/workers.html#max-tasks-per-child-setting

Note that this setting only works if we use the default 'prefork' pool support.  Currently, we do so as evidenced by the fact that we do not specify --pool at startup.

## Security Considerations

N/A