### PR TITLE
add eventlet debugging

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -6,6 +6,9 @@ import traceback
 import eventlet
 import gunicorn
 
+eventlet.monkey_patch()
+# This will give us a better stack trace if blocking occurs
+eventlet.debug.hub_blocking_detection(True)
 workers = 4
 worker_class = "eventlet"
 worker_connections = 256


### PR DESCRIPTION
## Description

We are trying to track down the source of the error "Do not call blocking functions from the main loop".

Previously we noticed that we were using eventlet.sleep() and that since we are using pool=threads for celery, that should be changed to time.sleep().  This is correct and debugging shows that the time.sleep() calls are not running in the main loop and are safe, but we still see the error.  So it is something else.

In the gunicorn_config, call the eventlet monkey patching immmediately.  Additionally enable debugging of blocking calls so we can get more information on what is actually happening.

Note:   General recommendations for this issue typically point to replacing eventlet with gthreads, hoping that by enabling debugging we can pinpoint the issue and avoid making random big changes to try to fix it.

## Security Considerations

N/A