### PR TITLE
Updated dependabot yml to remove depecrated review assignment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,3 @@ updates:
       - "dependabot" # Custom label to identify Dependabot PRs
     assignees:
       - "alexjanousekGSA"
-    reviewers:
-      - "alexjanousekGSA"


### PR DESCRIPTION
Reviewers for dependabot is deprecrated - this updated still keeps dependabot PR's assigned to me. https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/