### PR TITLE
Fix SocketIO WebSocket connections for production

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -104,6 +104,7 @@ redis_store = RedisClient()
 document_download_client = DocumentDownloadClient()
 
 socketio = SocketIO(
+    async_mode='gevent',
     cors_allowed_origins=[
         config.Config.ADMIN_BASE_URL,
     ],

--- a/gunicorn_entry.py
+++ b/gunicorn_entry.py
@@ -2,4 +2,7 @@ from gevent import monkey
 
 monkey.patch_all()
 
-from application import application  # noqa
+from application import application as flask_app  # noqa
+from app import socketio  # noqa
+
+application = socketio


### PR DESCRIPTION
The issue was that SocketIO didn't know we were using gevent workers in Gunicorn (eventlet is recommended), so it was trying to use a different connection method. By explicitly telling SocketIO to use gevent mode, it now properly handles WebSocket connections instead of falling back to the slower polling method.