### PR TITLE
Bump Staging API app memory to 1.5G

### DIFF
--- a/deploy-config/staging.yml
+++ b/deploy-config/staging.yml
@@ -1,6 +1,6 @@
 env: staging
 web_instances: 2
-web_memory: 1G
+web_memory: 1.5G
 worker_instances: 2
 worker_memory: 1G
 scheduler_memory: 256M


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

Please enter a detailed description here.

This changeset bumps the memory of the API app processes to 1.5G as they are now starting to run out of memory due to recent app changes with gunicorn and gevent.

## Security Considerations

* Making sure the app has enough memory available to it prevents random crashes from occurring.