### PR TITLE
make template_usage by month in descending order

### DIFF
--- a/app/dao/fact_notification_status_dao.py
+++ b/app/dao/fact_notification_status_dao.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from sqlalchemy import Date, case, cast, delete, func, select, union_all
+from sqlalchemy import Date, case, cast, delete, desc, func, select, union_all
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import extract, literal
@@ -108,6 +108,7 @@ def fetch_notification_status_for_service_by_month(start_date, end_date, service
             NotificationAllTimeView.notification_type,
             NotificationAllTimeView.status,
         )
+        .order_by(desc(func.date_trunc("month", NotificationAllTimeView.created_at)))
     )
     return db.session.execute(stmt).all()
 


### PR DESCRIPTION
## Description

Sort the template-usage by month page in reverse order (December, November etc).  If the year is the current year, only show months that have actually happened (ie start the list with the current month).

https://github.com/GSA/notifications-admin/issues/2884

## Security Considerations

N/A