### PR TITLE
Disable demo infrastructure drift check

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -44,44 +44,44 @@ jobs:
             exit $exit_code
           fi
 
-  check_demo_drift:
-    runs-on: ubuntu-latest
-    name: Check for drift of demo terraform configuration
-    environment: demo
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: 'production'
+  # check_demo_drift:
+  #   runs-on: ubuntu-latest
+  #   name: Check for drift of demo terraform configuration
+  #   environment: demo
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: 'production'
 
-      # Looks like we need to install Terraform ourselves now!
-      # https://github.com/actions/runner-images/issues/10796#issuecomment-2417064348
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "^1.7.5"
-          terraform_wrapper: false
+  #     # Looks like we need to install Terraform ourselves now!
+  #     # https://github.com/actions/runner-images/issues/10796#issuecomment-2417064348
+  #     - name: Setup Terraform
+  #       uses: hashicorp/setup-terraform@v3
+  #       with:
+  #         terraform_version: "^1.7.5"
+  #         terraform_wrapper: false
 
-      - name: Check for drift
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
-          TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
-          TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
-        run: |
-          cd terraform/demo
-          terraform init
-          terraform plan -detailed-exitcode
-          exit_code=$?
-          if [ $exit_code -eq 0 ]; then
-            echo "No changes detected.  Intrastructure is up-to-date."
-          elif [ $exit_code -eq 2 ]; then
-            echo "Changes detected.  Infrastructure drift found."
-            exit 1
-          else
-            echo "Error running terraform plan."
-            exit $exit_code
-          fi
+  #     - name: Check for drift
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_ACCESS_KEY }}
+  #         TF_VAR_cf_user: ${{ secrets.CLOUDGOV_USERNAME }}
+  #         TF_VAR_cf_password: ${{ secrets.CLOUDGOV_PASSWORD }}
+  #       run: |
+  #         cd terraform/demo
+  #         terraform init
+  #         terraform plan -detailed-exitcode
+  #         exit_code=$?
+  #         if [ $exit_code -eq 0 ]; then
+  #           echo "No changes detected.  Intrastructure is up-to-date."
+  #         elif [ $exit_code -eq 2 ]; then
+  #           echo "Changes detected.  Infrastructure drift found."
+  #           exit 1
+  #         else
+  #           echo "Error running terraform plan."
+  #           exit $exit_code
+  #         fi
 
   check_prod_drift:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*A note to PR reviewers: it may be helpful to review our [code review documentation](https://github.com/GSA/notifications-api/blob/main/docs/all.md#code-reviews) to know what to keep in mind while reviewing pull requests.*

## Description

This changeset disables the infrastructure drift check for our demo environment because we are no longer using the demo environment, and the infrastructure is in a known broken state.  More work will follow on in the future to clean things up fully.

## Security Considerations

* Normally we would want these checks to happen routinely and investigate and fix any drift that is detected; however, our demo environment is in a known broken state and we will be cleaning things up further in the future.