### PR TITLE
Fix documentation spelling errors from codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You will need the following items:
   [setting up an account](https://cloud.gov/sign-up/) (requires a `.mil`,
   `.gov`, or `.fed.us` email address) and getting access to the
   `notify-local-dev` and `notify-staging` spaces.
-- Admin priviliges and SSH access on your machine; you may need to work with
+- Admin privileges and SSH access on your machine; you may need to work with
   your organization's IT support staff if you're not sure or don't currently
   have this access.
 
@@ -414,7 +414,7 @@ JSON from the API in your web browser.
 
 This will run all of the services within the same shell session. If you need to
 run them separately to help with debugging or tracing logs, you can do so by
-opening three sepearate shell sessions and running one of these commands in each
+opening three separate shell sessions and running one of these commands in each
 one separately:
 
 - `make run-celery` - Handles the asynchronous jobs

--- a/docs/adrs/0002-how-to-handle-timezones.md
+++ b/docs/adrs/0002-how-to-handle-timezones.md
@@ -99,7 +99,7 @@ Pros of converting parts of the frontend now:
 Cons of converting parts of the frontend now:
 
 - There is a lot of additional work involved, not all touch points are known,
-  and there is a signficant effort underway at the moment to update the
+  and there is a significant effort underway at the moment to update the
   frontend design and information architecture.
 
 - We're still not entirely sure at which level of granularity we'd like to offer
@@ -140,7 +140,7 @@ We also need to update the frontend to account for these changes.  This will be
 done in two parts:
 
 1. We'll update the UI to make sure everything reflects ET where necessary for
-   any timzone displays.
+   any timezone displays.
 
 1. We need to create an ADR for future frontend work for how we'd like to handle
    timezones in the UI going forward.  This is currently noted in this issue:

--- a/docs/adrs/0003-implementing-invite-expirations.md
+++ b/docs/adrs/0003-implementing-invite-expirations.md
@@ -40,7 +40,7 @@ The system currently has a data model for capturing an invited user
 (`InvitedUser`), which is based on an authorized user of the system having the
 permission to invite others to it.
 
-These changes should not deviate from the existing structures and contraints
+These changes should not deviate from the existing structures and constraints
 that are already in place, which prevent the following:
 
 - Unauthorized users from accessing the system
@@ -108,7 +108,7 @@ value for the effort.
 
 ## VALIDATION AND NEXT STEPS
 
-Once a decision is made though, a seperate issue should be written up for the
+Once a decision is made though, a separate issue should be written up for the
 API changes that need to take place, and then follow-on work will be needed on
 the admin side in https://github.com/GSA/notifications-admin/issues/96 to make
 the UI adjustments.

--- a/docs/adrs/0004-designing-pilot-content-visibility.md
+++ b/docs/adrs/0004-designing-pilot-content-visibility.md
@@ -45,7 +45,7 @@ List all options that have either been discussed or thought of as a potential so
 
 **Pros:**
 
-- Allows for public vistors to know more about what the product is intended to do
+- Allows for public visitors to know more about what the product is intended to do
 - No need to scope a gated self-service solution
 
  **Cons:**
@@ -58,7 +58,7 @@ List all options that have either been discussed or thought of as a potential so
 
 **Pros:**
 
-- Invited users would go throught the `service creation wizard` flow and content
+- Invited users would go through the `service creation wizard` flow and content
 - A Studio team member would not need to create the initial account/service
 
 **Cons:**

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -42,7 +42,7 @@ First, we have an ADR issue template that folks can use to start. Select the
 "Create a new ADR" option when creating a new issue.
 
 By following the template, we ensure that our ADRs are consistent in language
-and structure.  This allows us to easily review the documentions and discuss
+and structure.  This allows us to easily review the documentation and discuss
 them as a team.  It also guarantees that the ADR has all of the required
 information.
 
@@ -54,7 +54,7 @@ active discussion and research taking place.  This is also why there is a
 Once an ADR has been reviewed and is ready to be finalized (either as accepted,
 rejected, or some other status), some final edits are made to update the ADR
 with decision details and next steps.  After this, future PRs can be opened to
-make additional updates, especially if an ADR becomes deprecated or superceded
+make additional updates, especially if an ADR becomes deprecated or superseded
 by another one.
 
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -265,14 +265,14 @@ We do not maintain any hooks in this repository.
 
 ## detect-secrets pre-commit plugin
 
-One of the pre-commit hooks we use is [`detect-secrets`](https://github.com/Yelp/detect-secrets), which checks for all sorts of things that might be committed accidently that should not be.  The project is already set up with a baseline file (`.ds.baseline`) and this should just work out of the box, but occasionally it will flag something new when you try and commit something; or, the file may need a refresh after a while.  In either case, to get things back on track and update the `.ds.baseline` file, run these two commands:
+One of the pre-commit hooks we use is [`detect-secrets`](https://github.com/Yelp/detect-secrets), which checks for all sorts of things that might be committed accidentally that should not be.  The project is already set up with a baseline file (`.ds.baseline`) and this should just work out of the box, but occasionally it will flag something new when you try and commit something; or, the file may need a refresh after a while.  In either case, to get things back on track and update the `.ds.baseline` file, run these two commands:
 
 ```sh
 detect-secrets scan --baseline .ds.baseline
 detect-secrets audit .ds.baseline
 ```
 
-The second command will walk you through all of the new detected secrets and ask you to validate if they actually are or if they're false positives.  Mark off each one as apppropriate (they should all be false positives - if they're not please stop and check in with the team!), then commit the updates to the `.ds.baseline` file and push them remotely so the project stays up-to-date.
+The second command will walk you through all of the new detected secrets and ask you to validate if they actually are or if they're false positives.  Mark off each one as appropriate (they should all be false positives - if they're not please stop and check in with the team!), then commit the updates to the `.ds.baseline` file and push them remotely so the project stays up-to-date.
 
 # Testing
 
@@ -413,7 +413,7 @@ As part of the deploy, we create an
 application to a select list of allowed domains.
 
 Update the allowed domains by updating `deploy-config/egress_proxy/notify-api-<env>.allow.acl`
-and deploying an updated version of the application throught he normal deploy process.
+and deploying an updated version of the application through the normal deploy process.
 
 ## Managing environment variables
 
@@ -618,7 +618,7 @@ cf run-task <CLOUD_GOV_APP from cf apps see above> --command "flask command upda
 
 # Commands for test loading the local dev database
 
-All commands use the `-g` or `--generate` to determine how many instances to load to the db. The `-g` or `--generate` option is required and will always defult to 1. An example: `flask command add-test-uses-to-db -g 6` will generate 6 random users and insert them into the db.
+All commands use the `-g` or `--generate` to determine how many instances to load to the db. The `-g` or `--generate` option is required and will always default to 1. An example: `flask command add-test-uses-to-db -g 6` will generate 6 random users and insert them into the db.
 
 ## Test commands list
 
@@ -877,7 +877,7 @@ Notify.gov is comprised of two applications both running on cloud.gov:
 Notify.gov utilizes several cloud.gov-provided services:
 
 - S3 buckets for temporary file storage
-- Elasticache (redis) for cacheing data and enqueueing background tasks
+- Elasticache (redis) for caching data and enqueueing background tasks
 - RDS (PostgreSQL) for system data storage
 
 Notify.gov also provisions and uses two AWS services via a [supplemental service broker](https://github.com/GSA/usnotify-ssb):
@@ -1170,7 +1170,7 @@ Add a title in the format of `<current date>` Production Deploy, e.g., `9/9/2024
 
 Lastly, uncheck the `Set as the latest release` checkbox and check the `Set as a pre-release` checkbox instead.
 
-Once everything is complete, cick on the `Publish release` button and then link to the new release notes in the corresponding production deploy pull request.
+Once everything is complete, click on the `Publish release` button and then link to the new release notes in the corresponding production deploy pull request.
 
 ### Review and approve the pull request(s)
 
@@ -1218,7 +1218,7 @@ Also known as: **How to move code from my machine to production**
 
 ### Common Policies and Procedures
 
-1. All changes must be made in a feature branch and opened as a PR targetting the `main` branch.
+1. All changes must be made in a feature branch and opened as a PR targeting the `main` branch.
 1. All PRs must be approved by another developer
 1. PRs to `main` and `production` branches must be merged by a someone with the `Administrator` role.
 1. PR documentation includes a Security Impact Analysis
@@ -1241,7 +1241,7 @@ Also known as: **How to move code from my machine to production**
 
 ### datagov-brokerpak-smtp
 
-1. To include new verisons of the SMTP brokerpak in released SSB code, create a PR in the `usnotify-ssb` repo updating the version in use in `app-setup-smtp.sh`
+1. To include new versions of the SMTP brokerpak in released SSB code, create a PR in the `usnotify-ssb` repo updating the version in use in `app-setup-smtp.sh`
 
 ### Vulnerability Mitigation Changes
 
@@ -1287,7 +1287,7 @@ If you're removing existing domains:
 
 Restage or redeploy the `notify-admin-production` app.  To restage, you can trigger the action in GitHub or run the command directly: `cf restage notify-admin-production --strategy rolling`.
 
-Test that the changes took effect properly by going to the domain(s) that were adjusted and seeing if they resolve correctly and/or no longer resolve as expected. Note that this may take up to 72 hours, depending on how long it takes for the DNS changes to propogate.
+Test that the changes took effect properly by going to the domain(s) that were adjusted and seeing if they resolve correctly and/or no longer resolve as expected. Note that this may take up to 72 hours, depending on how long it takes for the DNS changes to propagate.
 
 ## Exporting daily scan results for compliance monitoring
 
@@ -1630,7 +1630,7 @@ cf add-network-policy notify-admin-sandbox notify-api-sandbox --protocol tcp --p
 
 ### Service instance not found
 
-This error encounted after `cf push` indicates you may be using the wrong CloudFoundry target
+This error encountered after `cf push` indicates you may be using the wrong CloudFoundry target
 
 ```
 For application 'notify-api-sandbox': Service instance 'notify-api-rds-sandbox' not found

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -548,7 +548,7 @@ paths:
       requestBody:
         required: true
         description: |
-          The request body is a JSON object giving at least the phone nubmer to
+          The request body is a JSON object giving at least the phone number to
           deliver the message to and the template ID to send to that number.
 
           If the template has variables, provide them in the `personalisation`

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -42,7 +42,7 @@ Q: How did we set ourselves for success? What factors contributed to it? 
 
     -   We leveraged American Rescue Plan money and the TTS BPA to get a full development team onboard quickly.
 
-    -   Leveraging Customer Experience/Life Exeriences and Office of Evaluation Sciences priorities and people
+    -   Leveraging Customer Experience/Life Experiences and Office of Evaluation Sciences priorities and people
 
     -   We had a full team (product, UX, content, front-end and back-end engineering) from the beginning
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -112,7 +112,7 @@ These steps assume shared [Terraform state credentials](#terraform-state-credent
 These version numbers are hardcoded in Terraform or shell scripts. We should periodically check them for upgrades.
 
 * Cloud Foundry Terraform plugin in every module in the API and Admin apps, [here for example](sandbox/providers.tf#L6).
-* The [terraform-cloudgov module](https://github.com/GSA-TTS/terraform-cloudgov/), the version of which is referred to serveral times in most modules, [here for example](sandbox/main.tf#L16).
+* The [terraform-cloudgov module](https://github.com/GSA-TTS/terraform-cloudgov/), the version of which is referred to several times in most modules, [here for example](sandbox/main.tf#L16).
 * Cloud Service Broker (CSB) version in [the SMS](https://github.com/GSA/usnotify-ssb/blob/main/app-setup-sms.sh) and [the SMTP](https://github.com/GSA/usnotify-ssb/blob/main/app-setup-smtp.sh) download scripts of the usnotify-ssb repo.
 * SMS and SMTP brokerpak versions, also in the download scripts of the usnotify-ssb repo. (And we may have to help maintain the [SMTP brokerpak project](https://github.com/GSA-TTS/datagov-brokerpak-smtp) itself.)
 * The version of Redis used in deployed environment modules, [here for example](sandbox/main.tf#L33). To upgrade, the resource must be destroyed and replaced. The versions supported are limited by Cloud.gov.
@@ -137,7 +137,7 @@ The `development` module is rather different from the other environment modules.
 
 The `bootstrap` directory is not an environment module. Instead, it sets up infrastructure needed to deploy Terraform in any of the environments. If you are new to the project, [this is where you should start](#retrieving-existing-bucket-credentials).
 
-Similarly, `shared` is not an environment. It is a module that lends code to all the environments. Please note that changes to `shared` codebase will be applied to all envrionments the next time CI/CD (or a user) runs Terraform in that environment.
+Similarly, `shared` is not an environment. It is a module that lends code to all the environments. Please note that changes to `shared` codebase will be applied to all environments the next time CI/CD (or a user) runs Terraform in that environment.
 
 > [!WARNING]
 > Editing `shared` code is risky because it will be applied to production


### PR DESCRIPTION
## Summary
- Apply high-confidence spelling fixes in documentation files found by `codespell`.
- Keep scope limited to README/docs/terraform docs and OpenAPI prose text.
- Avoid code-path or behavior changes.

## Why
This improves documentation clarity and reduces avoidable reviewer/user confusion without altering runtime behavior.

## Validation
- `codespell README.md docs terraform/README.md`