### PR TITLE
Harden ADR workflow against issue-title command injection

### DIFF
--- a/.github/workflows/adr-accepted.yml
+++ b/.github/workflows/adr-accepted.yml
@@ -43,8 +43,10 @@ jobs:
     - name: build filename
       id: filename
       shell: bash
+      env:
+        ISSUE_TITLE: ${{ github.event.issue.title }}
       run: |
-        SLUG=$(printf '%q\n' "${{ github.event.issue.title }}" | tr A-Z a-z)
+        SLUG=$(printf '%q\n' "$ISSUE_TITLE" | tr A-Z a-z)
         SLUG=$(printf '%q\n' "$SLUG" | iconv -c -t ascii//TRANSLIT)
         SLUG=$(printf '%q\n' "$SLUG" | sed -E 's/[^a-z0-9]+/-/g' | sed -E 's/-+/-/g' | sed -E 's/^-+|-+$//g')
 
@@ -69,13 +71,14 @@ jobs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_TITLE: ${{ github.event.issue.title }}
       run: |
         BRANCH="adr/auto/${{ steps.filename.outputs.slug }}"
         git config --global user.email "tts@gsa.gov"
         git config --global user.name "Notify ADR Automation"
         git checkout -b $BRANCH
         git add docs/adrs/*.md
-        git commit -m "add ADR ${{ steps.next.outputs.number }}: ${{ github.event.issue.title }}"
+        git commit -m "add ADR ${{ steps.next.outputs.number }}: $ISSUE_TITLE"
         git push -f origin $BRANCH
         gh pr create \
           --title "Add ADR ${{ steps.next.outputs.number }} to the repo" \


### PR DESCRIPTION
Hi folks. I work on software supply chain security and have been reviewing GitHub Actions workflows across federal and public-sector repositories for untrusted-input handling. This is a small hardening change to `adr-accepted.yml`.

The workflow triggers on `issues` (closed) and uses `github.event.issue.title` inside two `run:` steps: the `printf` that builds the slug, and the `git commit -m` line. Actions expands `${{ ... }}` into the script body before bash executes it, so a closed issue whose title contains backticks or `$(...)` would have that text run as a shell command. The job checks out the repo with `SSH_PRIVATE_KEY` and auto-merges the generated PR, so the title is evaluated in a context that can write to the repository.

The fix moves the title into an `ISSUE_TITLE` environment variable and references `"$ISSUE_TITLE"` in the scripts. Environment values are not re-parsed by the shell, so the title is treated strictly as data. This is the approach GitHub recommends for the `actions/expression-injection` weakness. No behavior changes for normal ADR titles.

I left the `write-file-action` inputs alone since those are action inputs written into a markdown file that a human reviews before merge, not shell. Happy to adjust naming or split this further if you prefer.